### PR TITLE
Add named rooms and a few bug fixes

### DIFF
--- a/airena.js
+++ b/airena.js
@@ -9,111 +9,149 @@ var gameloop = require('node-gameloop');
 
 app.set('port', (process.env.PORT || 5000));
 
-var idArray = [];
-var codeArray = {};
-var sockets = {}
-var playerInfo = {}
+var games = {};
+var gameroom = function() {
+  this.idArray = [];
+  this.codeArray = {};
+  this.sockets = {};
+  this.playerInfo = {};
+
+  var self = this;
+
+  this.RunAICode = function(id){
+    try {
+      var output = self.codeArray[id].script.runInContext(self.codeArray[id].context);
+      var keys = output[0];
+      io.emit("key-press",{keyMap:keys,id:id})
+    } catch (e){
+      self.sockets[id].emit("syntax-error",{errorText:String(e)})
+    }
+  }
+
+  var fps = 60;
+  this.game = gameloop.setGameLoop(function(delta) {
+    //Keep running the code we have
+    for(var key in self.codeArray){
+      self.RunAICode(key)
+    }
+  }, 1000 / fps);
+
+}
 
 /////////////Tell Socket.io to accept connections
 io.on('connection', function(socket){
-  //A new user has connected! Inform everyone else
-  socket.broadcast.emit('new-user',socket.id)
-  //Tell this user how many players there are
-  socket.emit('initial-users',{idArray:idArray,own_id:socket.id})
-  idArray.push(socket.id);
-  sockets[socket.id] = socket;
-  console.log("Hello user!")//This will output on the server side
-  //Register new player
-  playerInfo[socket.id] = {x:0,y:0,rotation:0,health:1}
+
+  socket.on('join-game', function(msg) {
+    var game;
+
+    if ( games[msg.gameid] === undefined ) {
+      games[msg.gameid] = new gameroom(); // create a game if needed
+    }
+    game = games[msg.gameid];
+    socket.join(msg.gameid, function() { // join the room for the given game
+      socket.gameid = msg.gameid;
+      //A new user has connected! Inform everyone else
+      socket.broadcast.to(socket.gameid).emit('new-user',socket.id)
+      //Tell this user how many players there are
+      socket.emit('initial-users',{idArray:game.idArray,own_id:socket.id})
+      game.idArray.push(socket.id);
+      game.sockets[socket.id] = socket;
+      console.log("Hello user!")//This will output on the server side
+      //Register new player
+      game.playerInfo[socket.id] = {x:0,y:0,rotation:0,health:1}
+    });
+  });
 
   socket.on('disconnect', function(){
+    var game = games[socket.gameid];
+    if (game === undefined) { // don't care about disconnections not associated with an open game
+      return;
+    }
     console.log('user disconnected');
-    delete playerInfo[socket.id];
-    for(var i=0;i<idArray.length;i++){
-      if(idArray[i] == socket.id) {
-        idArray.splice(i,1);
-        socket.broadcast.emit('remove-user',socket.id)
+    delete game.playerInfo[socket.id];
+    for(var i=0;i<game.idArray.length;i++){
+      if(game.idArray[i] == socket.id) {
+        game.idArray.splice(i,1);
+        socket.broadcast.to(socket.gameid).emit('remove-user',socket.id)
         break;
       }
+    }
+    if (game.idArray.length == 0){  // no players left, shut the game down
+      delete games[socket.gameid];
+      console.log('Shutting down game with id '+socket.gameid);
+      return;
     }
   });
 
 
   //If the server gets a 'update-position' message, tell everyone
   socket.on('update-position', function(msg){
-    if(playerInfo[msg.player_id] == undefined) return;//Make sure this player actually exists here
-    socket.broadcast.emit('update-position', msg);
+    var game = games[socket.gameid];
+    if(game === undefined) {
+      return;
+    }
+    if(game.playerInfo[msg.player_id] == undefined) return; //Make sure this player actually exists here
+    socket.broadcast.to(socket.gameid).emit('update-position', msg);
     //Save position info
-    playerInfo[msg.player_id].x = msg.x;
-    playerInfo[msg.player_id].y = msg.y;
-    playerInfo[msg.player_id].rotation = msg.rot;
+    game.playerInfo[msg.player_id].x = msg.x;
+    game.playerInfo[msg.player_id].y = msg.y;
+    game.playerInfo[msg.player_id].rotation = msg.rot;
   });
 
   //Tell everyone when a health update occurs
   socket.on('update-health', function(msg){
-    socket.broadcast.emit('update-health', msg);
+    socket.broadcast.to(socket.gameid).emit('update-health', msg);
   })
   //Tell everyone when someone shoots
   socket.on('shoot', function(msg){
-    socket.broadcast.emit('shoot', msg);
+    socket.broadcast.to(socket.gameid).emit('shoot', msg);
   })
 
 
   //If the servers gets code, save it and keep running it
   socket.on('code-change',function(msg){
-    if(codeArray[msg.id] == undefined){
-      codeArray[msg.id] = {code:"",sandbox:{'saved':{}}}
-      codeArray[msg.id].context = vm.createContext(codeArray[msg.id].sandbox);
+    var game = games[socket.gameid];
+    if ( game === undefined ) { return; }
+    if( typeof(game.codeArray[msg.id]) === "undefined"){
+      var code = {code:"",sandbox:{'saved':{}}};
+      code.context = vm.createContext(code.sandbox);
+      game.codeArray[msg.id] = code;
     }
-    codeArray[msg.id].code = msg.savedCode;
+    game.codeArray[msg.id].code = msg.savedCode;
     try {
-      codeArray[msg.id].sandbox = {'saved':{}}
-      codeArray[msg.id].sandbox.enemyArray = []
-      //Construct enemyArray 
-      for(var key in playerInfo){
+      game.codeArray[msg.id].sandbox = {'saved':{}}
+      game.codeArray[msg.id].sandbox.enemyArray = []
+      //Construct enemyArray
+      for(var key in game.playerInfo){
         if(key == msg.id){
-          codeArray[msg.id].sandbox.player = playerInfo[key]
+          game.codeArray[msg.id].sandbox.player = game.playerInfo[key]
         } else {
-          codeArray[msg.id].sandbox.enemyArray.push(playerInfo[key])
+          game.codeArray[msg.id].sandbox.enemyArray.push(game.playerInfo[key])
         }
       }
-      codeArray[msg.id].context = vm.createContext(codeArray[msg.id].sandbox);
-      codeArray[msg.id].script = new vm.Script(msg.savedCode+"\ndoStep(player,enemyArray,saved);");
-      var output = codeArray[msg.id].script.runInContext(codeArray[msg.id].context);
+      game.codeArray[msg.id].context = vm.createContext(game.codeArray[msg.id].sandbox);
+      game.codeArray[msg.id].script = new vm.Script(msg.savedCode+"\ndoStep(player,enemyArray,saved);");
+      var output = game.codeArray[msg.id].script.runInContext(game.codeArray[msg.id].context);
       var keys = output[0]
       //console.log(util.inspect(sandbox));
-      io.emit("key-press",{keyMap:keys,id:msg.id})
+      io.to(socket.gameid).emit("key-press",{keyMap:keys,id:msg.id})
     } catch(e){
       socket.emit("syntax-error",{errorText:String(e)})
     }
-    
-    
+
+
   })
 
 });
 
-function RunAICode(id){
-  try {
-    var output = codeArray[id].script.runInContext(codeArray[id].context);
-    var keys = output[0]
-    //console.log(util.inspect(sandbox));
-    io.emit("key-press",{keyMap:keys,id:id})
-  } catch (e){
-    sockets[id].emit("syntax-error",{errorText:String(e)})
-  }
-}
-
-var fps = 60;
-gameloop.setGameLoop(function(delta) {
-  //Keep running the code we have
-  for(var key in codeArray){
-    RunAICode(key)
-  }
-}, 1000 / fps);
 
 
 ///////////////Start the server and such
 app.get('/', function(req, res){
+  var roomid = Math.random().toString(36).substr(2,5);
+  res.redirect('/'+roomid); // bounce landing page to a random room
+});
+app.get('/[a-z0-9]+$', function(req,res){
   res.sendFile(__dirname + '/index.html');
 });
 

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
   <head>
     <title>Airena</title>
     <!-- Include CodeMirror -->
-  <script src="src/lib/codemirror.js"></script>
-  <link rel="stylesheet" href="src/lib/codemirror.css">
-  <script src="src/lib/javascript.js"></script>
+  <script src="/src/lib/codemirror.js"></script>
+  <link rel="stylesheet" href="/src/lib/codemirror.css">
+  <script src="/src/lib/javascript.js"></script>
     <style>
     /* We want our scene to span the entire window */
     body {
@@ -97,10 +97,10 @@
       display: none;
     }
 
- 
+
   </style>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-  
+
 
   </head>
   <script src="/socket.io/socket.io.js"></script>
@@ -111,9 +111,9 @@
   <body>
   <canvas id="game_canvas" width="800" height="600"></canvas>
 
-  
+
   <div id="code_editor">
-    
+
   </div>
   <div id="error_banner">
     <span id="error_text">An example error!</span>
@@ -130,6 +130,6 @@
     <h1 class='noselect'>Game Over</h1>
     <p id="respawn" class='noselect'>Click to respawn</p>
   </div>
-  
+
   </body>
 </html>

--- a/src/init.js
+++ b/src/init.js
@@ -5,9 +5,9 @@ window.onload=function(){
 	createjs.Ticker.setFPS(60);
 	resize();
 	//Full screen canvas
-	function resize() { 
+	function resize() {
 	    stage.canvas.width = window.innerWidth;
-	    stage.canvas.height = window.innerHeight;     
+	    stage.canvas.height = window.innerHeight;
 	  }
 	//Game loop
 	createjs.Ticker.addEventListener("tick", handleTick);
@@ -121,7 +121,7 @@ window.onload=function(){
 
 	function GameUpdate(){
 		if(player.id == undefined) return;//Don't run anything until we're connected
-		if(keys[37]) player.rotateLeft() 
+		if(keys[37]) player.rotateLeft()
 		if(keys[39]) {
 			player.rotateRight()
 			//
@@ -132,7 +132,7 @@ window.onload=function(){
 		if(keys[32]) {
 			shootLaser()
 		}
-		
+
 
 		stage.x += ((-player.shape.x+stage.canvas.width/2) - stage.x) * 0.3 + Math.random() * quakePower;
 		stage.y += ((-player.shape.y+stage.canvas.height/2) - stage.y )* 0.3 + Math.random() * quakePower;
@@ -140,7 +140,7 @@ window.onload=function(){
 		tint.update()
 		//console.log(codeMirror.getValue())
 
-		
+
 
 		for(var p in playerArray) {
 			playerArray[p].update()
@@ -174,16 +174,16 @@ window.onload=function(){
 
 					var X = playerArray[p].shape.x;
 					var Y = playerArray[p].shape.y;
-					var d1 = CheckSide(X,Y,line1);	
+					var d1 = CheckSide(X,Y,line1);
 					var d2 = CheckSide(X,Y,line2);
 					var d3 = CheckSide(X,Y,line3);
 					var d4 = CheckSide(X,Y,line4);
-					
+
 					d1 = Math.abs(d1)/d1;
 					d2 = Math.abs(d2)/d2;
 					d3 = Math.abs(d3)/d3;
 					d4 = Math.abs(d4)/d4;
-					
+
 
 					if(d1 == d3 && d2 == d4){
 						playerArray[p].setHealth(0)
@@ -191,8 +191,8 @@ window.onload=function(){
 
 					}
 
-				
-				
+
+
 			}
 		}
 
@@ -204,7 +204,7 @@ window.onload=function(){
 			quake(20)
 			player.setHealth(player.health-0.2)
 			if(player.health <= 0.001) $('#game_over').css("display","block")
-			//Update health 
+			//Update health
 			socket.emit("update-health",{health:player.health,id:player.id})
 		}
 
@@ -247,12 +247,18 @@ window.onload=function(){
 	//Simulate key press
 	socket.on('key-press',function(msg){
 		var pl = player;
-		if(msg.id != player.id) pl = playerArray[msg.id];
+		if(msg.id != player.id) {
+      pl = playerArray[msg.id];
+    }
+		if(typeof(pl) === "undefined"){
+			console.error("Undefined player...");
+			return;
+		}
 		if(msg.keyMap['right']) pl.rotateRight();
 		if(msg.keyMap['left']) pl.rotateLeft();
 		if(msg.keyMap['up']) pl.thrust();
 		if(msg.keyMap['space']) shootLaser();
-	})	
+	})
 
 	//Someone is shooting!!
 	socket.on('shoot',function(msg){
@@ -302,7 +308,7 @@ window.onload=function(){
         });
 
 	$('#code_editor').css("display","none");
-	//Set up code button 
+	//Set up code button
 	$('#code_button').click(function(evt){
 		$('#code_button').css("display","none");
 		$('#close_button').css("display","block");
@@ -335,7 +341,7 @@ window.onload=function(){
 		$('#error_banner').css("display","block")
 		$('#error_text').html(msg.errorText)
 	})
-	
+
 	function quake(mag){
 		quakePower = mag;
 	}

--- a/src/init.js
+++ b/src/init.js
@@ -72,7 +72,9 @@ window.onload=function(){
 	player.shape.x = 300;
 	player.shape.y = 100;
 
+	var gameid = window.location.pathname.split("/")[1]; // this only looks at the first dir in path
 	var socket = io();
+	socket.emit('join-game', { gameid: gameid });
 	socket.on('new-user', function(id){
 		CreateEnemyUser(id)
 	});


### PR DESCRIPTION
6698bc0 addresses relative pathing to be more consistent with express on the server side, which is minor and not an essential part of this PR at all.

7232600 adds a test to catch some cases where a player is not defined, addressing #1

bef9ae4 is the bigger commit in this, and it adds named rooms based on the URL from which the client accesses the game (addressing a to-do in your readme which doesn't have a corresponding issue).  If the client accesses the root directory, the server throws them into a random 5-character room (e.g. `/ab123`).  If they access an alphanumeric URL with a base path of any length (e.g. `/ab123` or `/mycustomroom`) directly, they'll be put in the appropriate room.

The rooms themselves are implemented using socket.io's "room" feature, and work by means of the client emitting a `join-room` on establishing a connection.  The server creates a new `gameroom` object as necessary (and destroys it when it's no longer needed) to manage gameplay in individual rooms.

I tried to stick to your formatting and coding style where I could, but let me know if anything looks amiss!  Sorry about the whitespace garbage in the commits, my text editor was apparently hungry!
